### PR TITLE
fix pnwkit not functioning from require call in 2.2.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,5 +62,6 @@ for (const [key] of Object.entries(kit)) {
 
 exports.setKey = kit.setKey;
 exports.cached = kit.cached;
+exports.setRateLimit = kit.setRateLimit;
 
 export default kit;

--- a/test/src/index/suites/kit.test.ts
+++ b/test/src/index/suites/kit.test.ts
@@ -41,6 +41,7 @@ export default function suite() {
       assert.strictEqual(exported.cached, pnwkit.cached);
       assert.strictEqual(exported.allianceQuery, pnwkit.allianceQuery);
       assert.strictEqual(exported.setKey, pnwkit.setKey);
+      assert.strictEqual(exported.setRateLimit, pnwkit.setRateLimit);
     });
   });
 }


### PR DESCRIPTION
Fixes #10 by actually exporting the setRateLimit function that is required for it to work.